### PR TITLE
Create new Gradle projects with gauge-java 0.7.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.thoughtworks.gauge:gauge-java:0.7.2'
+    implementation 'com.thoughtworks.gauge:gauge-java:0.7.9'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "java_gradle",
   "description": "Gauge template for Java plugin with Gradle as Build tool",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "postInstallCmd": "./gradlew clean build",
   "postInstallMsg": "Run specifications with \"./gradlew gauge\" in project root."
 }


### PR DESCRIPTION
This updates default version of gauge-java for new Gradle projects to 0.7.9